### PR TITLE
Enable Github pages

### DIFF
--- a/otterdog/eclipse-equinox.jsonnet
+++ b/otterdog/eclipse-equinox.jsonnet
@@ -38,7 +38,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
       default_branch: "master",
       delete_branch_on_merge: false,
       gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "main",
+      gh_pages_source_branch: "master",
       gh_pages_source_path: "/docs",
       description: "equinox",
       has_discussions: true,

--- a/otterdog/eclipse-equinox.jsonnet
+++ b/otterdog/eclipse-equinox.jsonnet
@@ -37,6 +37,9 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     orgs.newRepo('equinox') {
       default_branch: "master",
       delete_branch_on_merge: false,
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "main",
+      gh_pages_source_path: "/docs",
       description: "equinox",
       has_discussions: true,
       web_commit_signoff_required: false,


### PR DESCRIPTION
We want to enable github pages for equinox as described here:

https://github.com/eclipse-equinox/equinox/pull/849

I'm not sure about the `gh_pages_build_type` setting but taken it from the Tycho otterdog file...