### PR TITLE
Disable squash-and-merge submission for all active repositories

### DIFF
--- a/otterdog/eclipse-equinox.jsonnet
+++ b/otterdog/eclipse-equinox.jsonnet
@@ -27,7 +27,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
   ],
   _repositories+:: [
     orgs.newRepo('.github') {
-      allow_merge_commit: true,
+      allow_squash_merge: false,
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       workflows+: {
@@ -36,6 +36,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('equinox') {
       default_branch: "master",
+      allow_squash_merge: false,
       delete_branch_on_merge: false,
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "master",
@@ -56,9 +57,9 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
       ],
     },
     orgs.newRepo('equinox-website') {
-      allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",
+      allow_squash_merge: false,
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       workflows+: {
@@ -67,6 +68,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('equinox.binaries') {
       default_branch: "master",
+      allow_squash_merge: false,
       delete_branch_on_merge: false,
       has_projects: false,
       has_wiki: false,
@@ -145,6 +147,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('p2') {
       default_branch: "master",
+      allow_squash_merge: false,
       delete_branch_on_merge: false,
       has_discussions: true,
       has_projects: false,


### PR DESCRIPTION
Similar to https://github.com/eclipse-pde/.eclipsefdn/pull/4 and as discussed in https://github.com/eclipse-platform/.eclipsefdn/pull/16#issuecomment-2955639598, this disables `squash-and-merge` and `merge-commit` submissions for all active `eclipse-platform` repositories and removes explicit disabling of merge commits (it's disabled by default).

Using Github's Squash-and-merge submission method obfuscates the Committer of a change because the value of the committer field is `GitHub <noreply@github.com>` and not the Name and email of the real committer.

See for example
- https://github.com/eclipse-pde/eclipse.pde/pull/1455#issuecomment-2437524603

and the discussion in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3084#issuecomment-2934114671

@eclipse-equinox/eclipse-equinox-project-leads please approve and apply this change.
