### PR TITLE
Enable automated deletion of branches for all active repositories

### DIFF
--- a/otterdog/eclipse-equinox.jsonnet
+++ b/otterdog/eclipse-equinox.jsonnet
@@ -36,8 +36,8 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('equinox') {
       default_branch: "master",
-      delete_branch_on_merge: true,
       allow_squash_merge: false,
+      delete_branch_on_merge: true,
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "master",
       gh_pages_source_path: "/docs",
@@ -59,8 +59,8 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     orgs.newRepo('equinox-website') {
       allow_update_branch: false,
       default_branch: "master",
-      delete_branch_on_merge: true,
       allow_squash_merge: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
         enabled: false,
@@ -68,8 +68,8 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('equinox.binaries') {
       default_branch: "master",
-      delete_branch_on_merge: true,
       allow_squash_merge: false,
+      delete_branch_on_merge: true,
       has_projects: false,
       has_wiki: false,
       web_commit_signoff_required: false,
@@ -147,8 +147,8 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('p2') {
       default_branch: "master",
-      delete_branch_on_merge: true,
       allow_squash_merge: false,
+      delete_branch_on_merge: true,
       has_discussions: true,
       has_projects: false,
       has_wiki: false,

--- a/otterdog/eclipse-equinox.jsonnet
+++ b/otterdog/eclipse-equinox.jsonnet
@@ -27,7 +27,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
   ],
   _repositories+:: [
     orgs.newRepo('.github') {
-      allow_merge_commit: true,
+      allow_squash_merge: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {

--- a/otterdog/eclipse-equinox.jsonnet
+++ b/otterdog/eclipse-equinox.jsonnet
@@ -28,7 +28,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
   _repositories+:: [
     orgs.newRepo('.github') {
       allow_merge_commit: true,
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
         default_workflow_permissions: "write",
@@ -36,7 +36,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('equinox') {
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "master",
       gh_pages_source_path: "/docs",
@@ -59,7 +59,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
         enabled: false,
@@ -67,7 +67,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('equinox.binaries') {
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_projects: false,
       has_wiki: false,
       web_commit_signoff_required: false,
@@ -145,7 +145,7 @@ orgs.newOrg('eclipse.equinox', 'eclipse-equinox') {
     },
     orgs.newRepo('p2') {
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_discussions: true,
       has_projects: false,
       has_wiki: false,


### PR DESCRIPTION
This makes it simpler to keep the repositories clean of unused branches (e.g. created by bots).

Similar to https://github.com/eclipse-platform/.eclipsefdn/pull/18

@eclipse-equinox/eclipse-equinox-project-leads please review and approve this change if you are fine with it.